### PR TITLE
Fixed PHP 8.2 deprecation warnings: 'creation of dynamic property'.

### DIFF
--- a/library/Zend/Db/Adapter/Pdo/Abstract.php
+++ b/library/Zend/Db/Adapter/Pdo/Abstract.php
@@ -44,6 +44,10 @@
  */
 abstract class Zend_Db_Adapter_Pdo_Abstract extends Zend_Db_Adapter_Abstract
 {
+    /**
+     * @var string
+     */
+    protected $_pdoType = '';
 
     /**
      * Default class name for a DB statement.


### PR DESCRIPTION
Fixes deprecation warnings with PHP 8.2: `Creation of dynamic property xxx is deprecated`

Found with phpstan:
1. Have latest version of [phpstan](https://github.com/phpstan/phpstan) installed somewhere (I've used version 1.10.15)
2. Clone this repo
3. Inside the repo, run:
```
$ /path/to/phpstan analyse --level=0 . | grep 'Access to an undefined property'
```
4. Expected to see no errors, but seeing:
```
  78     Access to an undefined property Zend_Db_Adapter_Pdo_Abstract::$_pdoType.
  107    Access to an undefined property Zend_Db_Adapter_Pdo_Abstract::$_pdoType.
  112    Access to an undefined property Zend_Db_Adapter_Pdo_Abstract::$_pdoType.
```

PR fixes:
- missing member

This fixes one of the warnings mentioned in https://github.com/magento/adobe-commerce-beta/issues/61, If I find more time and this PR actually gets approved, I might try to tackle the others as well one day.